### PR TITLE
Allow loading TCX from a string, for use in the browser

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,13 +7,13 @@ echo 'removing output files...'
 rm dist/*.*
 
 echo 'compiling the merge program...'
-tsc --build tsconfig-merge.json
+./node_modules/.bin/tsc --build tsconfig-merge.json
 
 echo 'executing the merge program...'
 node dist/merge.js src/tcx.ts
 
 echo 'compiling after merge...'
-tsc
+./node_modules/.bin/tsc
 
 echo 'src dir:'
 ls -al src/

--- a/mocha-junit-results.xml
+++ b/mocha-junit-results.xml
@@ -1,46 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Mocha Tests" time="0.716" tests="16" failures="0">
-  <testsuite name="Root Suite" timestamp="2019-07-29T17:36:12" tests="0" failures="0" time="0">
+<testsuites name="Mocha Tests" time="1.545" tests="17" failures="0">
+  <testsuite name="Root Suite" timestamp="2020-05-03T22:03:21" tests="0" failures="0" time="0">
   </testsuite>
-  <testsuite name="ElapsedTime" timestamp="2019-07-29T17:36:12" tests="0" file="/Users/cjoakim/github/tcx-js/test/test_etime.js" failures="0" time="0">
+  <testsuite name="ElapsedTime" timestamp="2020-05-03T22:03:21" tests="0" file="/Users/douglas/hack/tcx-js/test/test_etime.js" failures="0" time="0">
   </testsuite>
-  <testsuite name="#constructor()" timestamp="2019-07-29T17:36:12" tests="8" file="/Users/cjoakim/github/tcx-js/test/test_etime.js" failures="0" time="0.005">
+  <testsuite name="#constructor()" timestamp="2020-05-03T22:03:21" tests="8" file="/Users/douglas/hack/tcx-js/test/test_etime.js" failures="0" time="0.008">
     <testcase name="ElapsedTime #constructor() It should define constant values" time="0.004" classname="It should define constant values">
     </testcase>
     <testcase name="ElapsedTime #constructor() It should return the correct value for 0 ms" time="0" classname="It should return the correct value for 0 ms">
     </testcase>
-    <testcase name="ElapsedTime #constructor() It should return the correct value for 1000 ms" time="0" classname="It should return the correct value for 1000 ms">
+    <testcase name="ElapsedTime #constructor() It should return the correct value for 1000 ms" time="0.001" classname="It should return the correct value for 1000 ms">
     </testcase>
     <testcase name="ElapsedTime #constructor() It should return the correct value for -1000 ms" time="0" classname="It should return the correct value for -1000 ms">
     </testcase>
-    <testcase name="ElapsedTime #constructor() It should return the correct value for 62000 ms" time="0.001" classname="It should return the correct value for 62000 ms">
+    <testcase name="ElapsedTime #constructor() It should return the correct value for 62000 ms" time="0" classname="It should return the correct value for 62000 ms">
     </testcase>
-    <testcase name="ElapsedTime #constructor() It should return the correct value for 3663000 ms" time="0" classname="It should return the correct value for 3663000 ms">
+    <testcase name="ElapsedTime #constructor() It should return the correct value for 3663000 ms" time="0.001" classname="It should return the correct value for 3663000 ms">
     </testcase>
-    <testcase name="ElapsedTime #constructor() It should return the correct value for 3663200 ms" time="0" classname="It should return the correct value for 3663200 ms">
+    <testcase name="ElapsedTime #constructor() It should return the correct value for 3663200 ms" time="0.001" classname="It should return the correct value for 3663200 ms">
     </testcase>
-    <testcase name="ElapsedTime #constructor() It should return the correct value for 3663700.1 ms" time="0" classname="It should return the correct value for 3663700.1 ms">
+    <testcase name="ElapsedTime #constructor() It should return the correct value for 3663700.1 ms" time="0.001" classname="It should return the correct value for 3663700.1 ms">
     </testcase>
   </testsuite>
-  <testsuite name="GeoJsonLocation" timestamp="2019-07-29T17:36:12" tests="0" file="/Users/cjoakim/github/tcx-js/test/test_geo.js" failures="0" time="0">
+  <testsuite name="GeoJsonLocation" timestamp="2020-05-03T22:03:21" tests="0" file="/Users/douglas/hack/tcx-js/test/test_geo.js" failures="0" time="0">
   </testsuite>
-  <testsuite name="#constructor()" timestamp="2019-07-29T17:36:12" tests="1" file="/Users/cjoakim/github/tcx-js/test/test_geo.js" failures="0" time="0.001">
+  <testsuite name="#constructor()" timestamp="2020-05-03T22:03:21" tests="1" file="/Users/douglas/hack/tcx-js/test/test_geo.js" failures="0" time="0.001">
     <testcase name="GeoJsonLocation #constructor() It should return the correct value for Davidson College" time="0.001" classname="It should return the correct value for Davidson College">
     </testcase>
   </testsuite>
-  <testsuite name="Parser" timestamp="2019-07-29T17:36:12" tests="0" file="/Users/cjoakim/github/tcx-js/test/test_parser.js" failures="0" time="0">
+  <testsuite name="Parser" timestamp="2020-05-03T22:03:21" tests="0" file="/Users/douglas/hack/tcx-js/test/test_parser.js" failures="0" time="0">
   </testsuite>
-  <testsuite name="#constructor()" timestamp="2019-07-29T17:36:12" tests="3" file="/Users/cjoakim/github/tcx-js/test/test_parser.js" failures="0" time="0.71">
+  <testsuite name="#constructor()" timestamp="2020-05-03T22:03:21" tests="4" file="/Users/douglas/hack/tcx-js/test/test_parser.js" failures="0" time="1.536">
     <testcase name="Parser #constructor() defines a VERSION" time="0" classname="defines a VERSION">
     </testcase>
-    <testcase name="Parser #constructor() It should return the correct value for file activity_twin_cities_marathon.tcx" time="0.288" classname="It should return the correct value for file activity_twin_cities_marathon.tcx">
+    <testcase name="Parser #constructor() It should return the correct value for file activity_twin_cities_marathon.tcx" time="0.491" classname="It should return the correct value for file activity_twin_cities_marathon.tcx">
     </testcase>
-    <testcase name="Parser #constructor() It should return the correct value for file alex_bike_outside.tcx" time="0.422" classname="It should return the correct value for file alex_bike_outside.tcx">
+    <testcase name="Parser #constructor() It should return the correct value for file alex_bike_outside.tcx" time="0.605" classname="It should return the correct value for file alex_bike_outside.tcx">
+    </testcase>
+    <testcase name="Parser #constructor() It should return the correct values when given text contents of alex_bike_outside.tcx" time="0.44" classname="It should return the correct values when given text contents of alex_bike_outside.tcx">
     </testcase>
   </testsuite>
-  <testsuite name="Timestamp" timestamp="2019-07-29T17:36:12" tests="0" file="/Users/cjoakim/github/tcx-js/test/test_ts.js" failures="0" time="0">
+  <testsuite name="Timestamp" timestamp="2020-05-03T22:03:22" tests="0" file="/Users/douglas/hack/tcx-js/test/test_ts.js" failures="0" time="0">
   </testsuite>
-  <testsuite name="#constructor()" timestamp="2019-07-29T17:36:12" tests="4" file="/Users/cjoakim/github/tcx-js/test/test_ts.js" failures="0" time="0">
+  <testsuite name="#constructor()" timestamp="2020-05-03T22:03:22" tests="4" file="/Users/douglas/hack/tcx-js/test/test_ts.js" failures="0" time="0">
     <testcase name="Timestamp #constructor() It should return the correct value for 1970-01-01T00:00:00.000Z" time="0" classname="It should return the correct value for 1970-01-01T00:00:00.000Z">
     </testcase>
     <testcase name="Timestamp #constructor() It should return the correct value for 1970-01-01T00:00:01.000Z" time="0" classname="It should return the correct value for 1970-01-01T00:00:01.000Z">

--- a/mocha-xunit-results.xml
+++ b/mocha-xunit-results.xml
@@ -1,16 +1,17 @@
-<testsuite name="Mocha Tests" tests="16" failures="0" errors="0" skipped="0" timestamp="Mon, 29 Jul 2019 17:36:12 GMT" time="0.761">
+<testsuite name="Mocha Tests" tests="17" failures="0" errors="0" skipped="0" timestamp="Sun, 03 May 2020 22:03:22 GMT" time="1.674">
 <testcase classname="ElapsedTime #constructor()" name="It should define constant values" time="0.004"/>
 <testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 0 ms" time="0"/>
-<testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 1000 ms" time="0"/>
+<testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 1000 ms" time="0.001"/>
 <testcase classname="ElapsedTime #constructor()" name="It should return the correct value for -1000 ms" time="0"/>
-<testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 62000 ms" time="0.001"/>
-<testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 3663000 ms" time="0"/>
-<testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 3663200 ms" time="0"/>
-<testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 3663700.1 ms" time="0"/>
+<testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 62000 ms" time="0"/>
+<testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 3663000 ms" time="0.001"/>
+<testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 3663200 ms" time="0.001"/>
+<testcase classname="ElapsedTime #constructor()" name="It should return the correct value for 3663700.1 ms" time="0.001"/>
 <testcase classname="GeoJsonLocation #constructor()" name="It should return the correct value for Davidson College" time="0.001"/>
 <testcase classname="Parser #constructor()" name="defines a VERSION" time="0"/>
-<testcase classname="Parser #constructor()" name="It should return the correct value for file activity_twin_cities_marathon.tcx" time="0.288"/>
-<testcase classname="Parser #constructor()" name="It should return the correct value for file alex_bike_outside.tcx" time="0.422"/>
+<testcase classname="Parser #constructor()" name="It should return the correct value for file activity_twin_cities_marathon.tcx" time="0.491"/>
+<testcase classname="Parser #constructor()" name="It should return the correct value for file alex_bike_outside.tcx" time="0.605"/>
+<testcase classname="Parser #constructor()" name="It should return the correct values when given text contents of alex_bike_outside.tcx" time="0.44"/>
 <testcase classname="Timestamp #constructor()" name="It should return the correct value for 1970-01-01T00:00:00.000Z" time="0"/>
 <testcase classname="Timestamp #constructor()" name="It should return the correct value for 1970-01-01T00:00:01.000Z" time="0"/>
 <testcase classname="Timestamp #constructor()" name="It should return the correct value for 1970-01-01T00:00:01.234Z" time="0"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tcx-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.5.0"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/highlight": {
@@ -19,9 +19,9 @@
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "esutils": "2.0.2",
-        "js-tokens": "4.0.0"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
       }
     },
     "@types/chai": {
@@ -48,7 +48,7 @@
       "integrity": "sha512-O6Xgai01b9PB3IGA0lRIp1Ex3JBcxGDhdO0n3NIIpCyDOAjxcIGQFmkvgJpP8anTrthxOUQjBfLdRRi0Zn/TXA==",
       "dev": true,
       "requires": {
-        "@types/node": "12.6.8"
+        "@types/node": "*"
       }
     },
     "ansi-colors": {
@@ -69,7 +69,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "argparse": {
@@ -78,7 +78,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "assertion-error": {
@@ -99,7 +99,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -127,12 +127,12 @@
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chai-almost": {
@@ -141,8 +141,8 @@
       "integrity": "sha1-Q9AmzzvnmhzVE88Vr4QKgSQ6S2A=",
       "dev": true,
       "requires": {
-        "deep-eql": "2.0.2",
-        "type-detect": "4.0.8"
+        "deep-eql": "^2.0.2",
+        "type-detect": "^4.0.3"
       },
       "dependencies": {
         "deep-eql": {
@@ -151,7 +151,7 @@
           "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
           "dev": true,
           "requires": {
-            "type-detect": "3.0.0"
+            "type-detect": "^3.0.0"
           },
           "dependencies": {
             "type-detect": {
@@ -170,9 +170,9 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "supports-color": {
@@ -181,7 +181,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -204,9 +204,9 @@
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "code-point-at": {
@@ -248,11 +248,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.5",
-        "path-key": "2.0.1",
-        "semver": "5.7.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypt": {
@@ -267,7 +267,7 @@
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.1.1"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -282,7 +282,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "define-properties": {
@@ -291,7 +291,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "diff": {
@@ -312,7 +312,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "es-abstract": {
@@ -321,12 +321,12 @@
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.2.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4",
-        "object-keys": "1.1.1"
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
       }
     },
     "es-to-primitive": {
@@ -335,9 +335,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.2"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -364,13 +364,13 @@
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "6.0.5",
-        "get-stream": "4.1.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "find-up": {
@@ -379,7 +379,7 @@
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
-        "locate-path": "3.0.0"
+        "locate-path": "^3.0.0"
       }
     },
     "flat": {
@@ -388,7 +388,7 @@
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "dev": true,
       "requires": {
-        "is-buffer": "2.0.3"
+        "is-buffer": "~2.0.3"
       }
     },
     "fs.realpath": {
@@ -421,7 +421,7 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "requires": {
-        "pump": "3.0.0"
+        "pump": "^3.0.0"
       }
     },
     "glob": {
@@ -430,12 +430,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.4",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -450,7 +450,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -477,8 +477,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -523,7 +523,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-stream": {
@@ -538,7 +538,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.0"
+        "has-symbols": "^1.0.0"
       }
     },
     "isexe": {
@@ -559,8 +559,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "lcid": {
@@ -569,7 +569,7 @@
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
-        "invert-kv": "2.0.0"
+        "invert-kv": "^2.0.0"
       }
     },
     "locate-path": {
@@ -578,8 +578,8 @@
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
-        "p-locate": "3.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -594,7 +594,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2"
+        "chalk": "^2.0.1"
       }
     },
     "map-age-cleaner": {
@@ -603,7 +603,7 @@
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "p-defer": "1.0.0"
+        "p-defer": "^1.0.0"
       }
     },
     "md5": {
@@ -612,9 +612,9 @@
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "dev": true,
       "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "1.1.6"
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       },
       "dependencies": {
         "is-buffer": {
@@ -631,9 +631,9 @@
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "0.1.3",
-        "mimic-fn": "2.1.0",
-        "p-is-promise": "2.1.0"
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
       }
     },
     "mimic-fn": {
@@ -648,7 +648,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -703,11 +703,11 @@
       "integrity": "sha512-qeDvKlZyAH2YJE1vhryvjUQ06t2hcnwwu4k5Ddwn0GQINhgEYFhlGM0DwYCVUHq5cuo32qAW6HDsTHt7zz99Ng==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "md5": "2.2.1",
-        "mkdirp": "0.5.1",
-        "strip-ansi": "4.0.0",
-        "xml": "1.0.1"
+        "debug": "^2.2.0",
+        "md5": "^2.1.0",
+        "mkdirp": "~0.5.1",
+        "strip-ansi": "^4.0.0",
+        "xml": "^1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -733,8 +733,8 @@
       "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
       "dev": true,
       "requires": {
-        "debug": "3.2.6",
-        "lodash": "4.17.14"
+        "debug": "^3.1.0",
+        "lodash": "^4.16.4"
       }
     },
     "ms": {
@@ -755,8 +755,8 @@
       "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
       "dev": true,
       "requires": {
-        "object.getownpropertydescriptors": "2.0.3",
-        "semver": "5.7.0"
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
       }
     },
     "npm-run-path": {
@@ -765,7 +765,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -786,10 +786,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "object-keys": "1.1.1"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.getownpropertydescriptors": {
@@ -798,8 +798,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "once": {
@@ -808,7 +808,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "os-locale": {
@@ -817,9 +817,9 @@
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
-        "execa": "1.0.0",
-        "lcid": "2.0.0",
-        "mem": "4.3.0"
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
       }
     },
     "p-defer": {
@@ -846,7 +846,7 @@
       "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "dev": true,
       "requires": {
-        "p-try": "2.2.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
@@ -855,7 +855,7 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
-        "p-limit": "2.2.0"
+        "p-limit": "^2.0.0"
       }
     },
     "p-try": {
@@ -900,8 +900,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "require-directory": {
@@ -922,7 +922,7 @@
       "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "sax": {
@@ -948,7 +948,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -975,8 +975,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "strip-ansi": {
@@ -985,7 +985,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-eof": {
@@ -1006,7 +1006,7 @@
       "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "tslib": {
@@ -1021,19 +1021,19 @@
       "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "builtin-modules": "1.1.1",
-        "chalk": "2.4.2",
-        "commander": "2.20.0",
-        "diff": "3.5.0",
-        "glob": "7.1.3",
-        "js-yaml": "3.13.1",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "resolve": "1.11.1",
-        "semver": "5.7.0",
-        "tslib": "1.10.0",
-        "tsutils": "2.29.0"
+        "@babel/code-frame": "^7.0.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.29.0"
       }
     },
     "tsutils": {
@@ -1042,7 +1042,7 @@
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
-        "tslib": "1.10.0"
+        "tslib": "^1.8.1"
       }
     },
     "type-detect": {
@@ -1063,7 +1063,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -1078,7 +1078,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "wrap-ansi": {
@@ -1087,8 +1087,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1103,7 +1103,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -1112,9 +1112,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -1123,7 +1123,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -1145,8 +1145,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
@@ -1166,17 +1166,17 @@
       "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
       "dev": true,
       "requires": {
-        "cliui": "4.1.0",
-        "find-up": "3.0.0",
-        "get-caller-file": "2.0.5",
-        "os-locale": "3.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "2.0.0",
-        "set-blocking": "2.0.0",
-        "string-width": "3.1.0",
-        "which-module": "2.0.0",
-        "y18n": "4.0.0",
-        "yargs-parser": "13.0.0"
+        "cliui": "^4.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1191,9 +1191,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -1202,7 +1202,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -1213,8 +1213,8 @@
       "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
       "dev": true,
       "requires": {
-        "camelcase": "5.3.1",
-        "decamelize": "1.2.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     },
     "yargs-unparser": {
@@ -1223,9 +1223,9 @@
       "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
       "dev": true,
       "requires": {
-        "flat": "4.1.0",
-        "lodash": "4.17.14",
-        "yargs": "12.0.5"
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
       },
       "dependencies": {
         "get-caller-file": {
@@ -1246,18 +1246,18 @@
           "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "3.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "11.1.1"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
           }
         },
         "yargs-parser": {
@@ -1266,8 +1266,8 @@
           "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -36,10 +36,12 @@ export class Parser {
     public activity : Activity = new Activity();
     public tcx_filename: string = '';
 
-    public constructor(infile: string) {
+    public constructor(infile: string, tcx_xml_str?: string) {
         this.tcx_filename = infile;
         this.activity.tcx_filename = infile;
-        let tcx_xml_str = fs.readFileSync(infile).toString();
+        if ( !tcx_xml_str ) {
+            tcx_xml_str = fs.readFileSync(infile).toString();
+        }
         let root_obj : JsonObject = <JsonObject> this.convertXmlToJson(tcx_xml_str);
         let tcdb : JsonObject = <JsonObject> root_obj["TrainingCenterDatabase"];
         let tcdb_file = this.tcx_filename + ".json";

--- a/src/tcx.ts
+++ b/src/tcx.ts
@@ -363,10 +363,12 @@ export class Parser {
     public activity : Activity = new Activity();
     public tcx_filename: string = '';
 
-    public constructor(infile: string) {
+    public constructor(infile: string, tcx_xml_str?: string) {
         this.tcx_filename = infile;
         this.activity.tcx_filename = infile;
-        let tcx_xml_str = fs.readFileSync(infile).toString();
+        if ( !tcx_xml_str ) {
+            tcx_xml_str = fs.readFileSync(infile).toString();
+        }
         let root_obj : JsonObject = <JsonObject> this.convertXmlToJson(tcx_xml_str);
         let tcdb : JsonObject = <JsonObject> root_obj["TrainingCenterDatabase"];
         let tcdb_file = this.tcx_filename + ".json";

--- a/test/test_parser.js
+++ b/test/test_parser.js
@@ -1,6 +1,7 @@
 // Unit tests for class Parser
 // Chris Joakim, 2019/07/29
 
+const fs = require('fs');
 const assert = require('assert');
 const chai   = require('chai');
 const chaiAlmost = require('chai-almost');
@@ -296,6 +297,24 @@ describe('Parser', function() {
       expect(hightestWatts).to.be.almost(957.0);
       expect(lastWatts).to.be.almost(16.0);
     });
+
+    it('It should return the correct values when given text contents of alex_bike_outside.tcx', function() {
+      var infile = 'data/alex_bike_outside_pretty.tcx';
+      let tcx_xml_data = fs.readFileSync(infile, 'utf8');
+
+      var parser = new Parser('fakename.tcx', tcx_xml_data);
+
+      activity = parser.activity;
+      author = activity.author;
+      creator = activity.creator;
+      trackpoints = activity.trackpoints;
+
+      expect(activity.sport).to.equal('Biking');
+      expect(activity.activityId).to.equal('2018-07-29T07:34:11Z');
+
+      expect(author.name).to.equal('FitnessSyncer.com');
+    });
+    
 
   });
 


### PR DESCRIPTION
Hi,

Thanks for the great work on this library! I wanted to use it for a simple browser-based visualisation with a file input, but the fs library is not available cient-side. I changed the Parser constructor to accept an optional argument: the contents of the TCX file as a string. With this small modification I can now load a TCX file with FileReader or fetch before processing the contents with your Parser.

I've included a simple example in `parser_test.js` - the test still reads the file with fs, but the point is that any file reading method could be used.